### PR TITLE
fix(endpoints): resolve userId from userLogin in DELETE__delete_user

### DIFF
--- a/packages/k6-tdk/src/endpoints/graph-v1-users.ts
+++ b/packages/k6-tdk/src/endpoints/graph-v1-users.ts
@@ -1,3 +1,5 @@
+import { objectToQueryString } from '@/utils'
+
 import { Endpoint } from './endpoints'
 
 export const POST__create_user: Endpoint<{ userLogin: string, userPassword: string }, 'text'> = (httpClient, {
@@ -12,8 +14,24 @@ export const POST__create_user: Endpoint<{ userLogin: string, userPassword: stri
   }))
 }
 
-export const DELETE__delete_user: Endpoint<{ userLogin: string }, 'none'> = (httpClient, { userLogin }) => {
-  return httpClient('DELETE', `/graph/v1.0/users/${userLogin}`)
+export const GET__get_users: Endpoint<{ params?: Record<string, unknown> }, 'text'> = (httpClient, { params }) => {
+  return httpClient('GET', `/graph/v1.0/users?${objectToQueryString(params)}`)
+}
+
+// LibreGraph API requires userId (UUID), not userLogin (username).
+// If only userLogin is provided, we lookup the userId first.
+export const DELETE__delete_user: Endpoint<{ userId?: string, userLogin?: string }, 'none'> = (httpClient, { userId, userLogin }) => {
+  let resolvedUserId = userId
+  if (!resolvedUserId && userLogin) {
+    const response = GET__get_users(httpClient, {})
+    const users = response ? JSON.parse(response.body).value : []
+    const user = users.find((u: { onPremisesSamAccountName: string }) => u.onPremisesSamAccountName === userLogin)
+    resolvedUserId = user?.id
+  }
+  if (!resolvedUserId) {
+    return httpClient('DELETE', '/graph/v1.0/users/unknown') // will 404
+  }
+  return httpClient('DELETE', `/graph/v1.0/users/${resolvedUserId}`)
 }
 
 export const POST__add_app_role_to_user: Endpoint<{


### PR DESCRIPTION
## Description

`DELETE__delete_user` used `userLogin` (username) in the URL path, but LibreGraph API requires the user's UUID. This caused 404 errors when deleting users via `_seeds-down-k6.js`.

Fix: Add `GET__get_users` endpoint and auto-resolve UUID from username in `DELETE__delete_user` if only `userLogin` is provided.

Only `graph-v1-users.ts` is changed. No changes to client or test files needed. Backwards compatible - existing callers using `{ userLogin }` continue to work.

## Related Issue

- Fixes https://github.com/opencloud-eu/cdperf/issues/10

## How Has This Been Tested?

- test environment: OpenCloud 4.1 (opencloud-rolling:4.1)
- test case 1: `pnpm build` passes
- test case 2: `k6 run _seeds-up-k6.js` - 100% checks passed (764/764)
- test case 3: `k6 run _seeds-down-k6.js` - 100% checks passed (10/10), including `✓ client -> user.deleteUser - status`

**Before (from issue #10):**
```
DELETE /graph/v1.0/users/perf-test-user-1 → 404
DELETE /graph/v1.0/users/perf-test-user-2 → 404
```

**After (Loki access logs):**
```
DELETE /graph/v1.0/users/d692d2d5-604c-42c0-ab9d-abccab6c5138 → 204
DELETE /graph/v1.0/users/1e63d2bd-c3ee-4770-9c88-0e1f7740f0b6 → 204
```

## Types of changes

- [x] Bugfix
- [ ] Enhancement (a change that doesn't break existing code or deployments)
- [ ] Breaking change (a modification that affects current functionality)
- [ ] Technical debt (addressing code that needs refactoring or improvements)
- [ ] Tests (adding or improving tests)
- [ ] Documentation (updates or additions to documentation)
- [ ] Maintenance (like dependency updates or tooling adjustments)
